### PR TITLE
:pencil2: Rename project

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -18,7 +18,7 @@ const Header: React.FC<Props> = () => {
             <div className="w-full flex justify-between items-center py-3 px-7 max-w-screen-lg mx-auto">
                 <div className="whitespace-nowrap flex-nowrap">
                     <p className="text-xl font-bold tracking-tight text-white m-0 p-0">
-                        Spotify Playlist Composer
+                        Spotify Composer
                     </p>
                     <p className="text-sm font-normal tracking-tight text-white opacity-75 -mt-1">
                         by Inception Cloud

--- a/src/spotify/playlists.ts
+++ b/src/spotify/playlists.ts
@@ -52,7 +52,7 @@ export async function createPlaylist(): Promise<Playlist> {
         body: JSON.stringify({
             name: `${getRandomEmoji()} ${profile.display_name}'s Composed Playlist`,
             description:
-                "🔥 Generated with the Spotify Playlist Composer by Inception Cloud. " +
+                "🔥 Generated with the Spotify Composer by Inception Cloud. " +
                 "👉 Create your own one at composer.inceptioncloud.net!",
         }),
     })


### PR DESCRIPTION
Change the name from Spotify Playlist Composer to **Spotify Composer**.
Update usages of the name in Header component and description of generated playlists.