### PR TITLE
Correctly handle songs with no album cover

### DIFF
--- a/src/components/composer/finish/PlaylistCover.tsx
+++ b/src/components/composer/finish/PlaylistCover.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react"
-import { AlbumImage, Song } from "../../../types/spotify"
+import { AlbumImage, Song } from "@typedefs/spotify"
 
 type Props = {
     songs: Song[]
@@ -8,7 +8,7 @@ type Props = {
 const PlaylistCover: React.FC<Props> = ({ songs }) => {
     const canvasSize = 250
     const canvasRef = useRef<HTMLCanvasElement | null>(null)
-    const [images, setImages] = useState<AlbumImage[]>([])
+    const [images, setImages] = useState<(AlbumImage | null)[]>([])
     const [imageIndex, setImageIndex] = useState(0)
     useEffect(() => {
         const canvas = canvasRef.current
@@ -18,6 +18,8 @@ const PlaylistCover: React.FC<Props> = ({ songs }) => {
             ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height)
             if (images.length >= 4) {
                 images.forEach((image, i) => {
+                    if (!image) return
+
                     let left = 0
                     let top = 0
                     if (i <= 1) left = i * (canvasSize / 2)
@@ -28,7 +30,7 @@ const PlaylistCover: React.FC<Props> = ({ songs }) => {
                     }
                     const img = document.createElement("img")
                     img.crossOrigin = "anonymous"
-                    img.src = image.url
+                    img.src = image!.url
                     img.addEventListener("load", () => {
                         ctx.drawImage(img, 0, 0, img.width, img.height, left, top, canvasSize / 2, canvasSize / 2)
                     })
@@ -61,7 +63,7 @@ const PlaylistCover: React.FC<Props> = ({ songs }) => {
         setImages(resolveImages())
     }, [songs])
 
-    function changeCoverImage(e: React.MouseEvent<HTMLCanvasElement, MouseEvent>, image: AlbumImage) {
+    function changeCoverImage(e: React.MouseEvent<HTMLCanvasElement, MouseEvent>, image: AlbumImage | null) {
         console.log("Set image:", image)
         console.log(imageIndex)
         setImages(prev => {

--- a/src/components/composer/finish/SongItem.tsx
+++ b/src/components/composer/finish/SongItem.tsx
@@ -10,9 +10,11 @@ const SongItem: React.FC<Props> = ({ song }) => {
     const durationSeconds = Math.round(totalSeconds % 60)
     const duration = Math.floor(totalSeconds / 60) + ":" + (durationSeconds < 10 ? "0" + durationSeconds : durationSeconds)
 
+    const cover = song.track.album.images[0]?.url
+
     return (
         <div key={song.track.id} className="w-full bg-white rounded-lg shadow-sm my-2 flex h-12">
-            <img src={song.track.album.images[0].url} alt="album cover" className="h-full rounded-l-lg"/>
+            <img src={cover} style={{ opacity: cover ? "1" : "0" }} alt="album cover" className="h-12 w-12 rounded-l-lg"/>
             <div className="h-full flex flex-col flex-grow justify-center ml-2 mr-4 overflow-hidden">
                 <h1 className="text-md font-medium tracking-tight truncate">{song.track.name}</h1>
                 <p className="text-sm leading-4 font-light tracking-tight truncate">

--- a/src/components/composer/song/SongBackground.tsx
+++ b/src/components/composer/song/SongBackground.tsx
@@ -8,7 +8,7 @@ const SongBackground: React.FC<Props> = ({ currentSong }) => {
         <div className="flex-grow transform scale-105 bg-cover bg-center"
              style={{
                  backgroundColor: "#000000",
-                 backgroundImage: `url('${currentSong.track.album.images[0].url}')`,
+                 backgroundImage: `url('${currentSong.track.album.images[0]?.url}')`,
                  filter: "blur(10px)"
              }}
         />

--- a/src/types/spotify.d.ts
+++ b/src/types/spotify.d.ts
@@ -37,7 +37,7 @@ export interface Artist {
 }
 
 export interface Album {
-    images: AlbumImage[]
+    images: (AlbumImage | null)[]
     id: string
 }
 


### PR DESCRIPTION
The code assumes that every Spotify song has information about its album along with a cover image returned from the API. However, there are songs on the Spotify platform (usually old ones which are no longer available) without an album cover. These songs cause the whole app to crash, which should be fixed with this PR.