### PR TITLE
Filter out unavailable songs

### DIFF
--- a/src/spotify/playlists.ts
+++ b/src/spotify/playlists.ts
@@ -36,6 +36,7 @@ export async function getAllSongs(playlists: string[]): Promise<Song[]> {
         const playlist = await getPlaylist(id)
         for (let song of playlist.tracks.items) {
             if (isAlreadyAdded(song)) continue
+            if (song.is_local || song.track.is_local || !song.track.track) continue
             result.push(song)
         }
     }

--- a/src/types/spotify.d.ts
+++ b/src/types/spotify.d.ts
@@ -19,12 +19,15 @@ export interface Playlist {
 }
 
 export interface Song {
+    is_local: boolean
     track: {
         name: string
         id: string
         uri: string
+        is_local: boolean
+        track?: boolean
         external_ids: {
-            isrc: string
+            isrc?: string
         }
         duration_ms: number
         artists: Artist[]


### PR DESCRIPTION
- Update types to closer match the Spotify API response schema
- Filter out songs which are practically unavailable on Spotify and caused the playlist creation process to fail