### PR TITLE
✨ Advance song preview feature

### DIFF
--- a/src/components/composer/song/SongAudioControls.tsx
+++ b/src/components/composer/song/SongAudioControls.tsx
@@ -13,14 +13,14 @@ const SongAudioControls: React.FC<Props> = ({ volume, setVolume }) => {
     const percentage = (volume / max) * 100
 
     const [expanded, setExpanded] = useState(false)
-    const beforeMute = useRef(0.15)
+    const beforeMute = useRef(volume)
 
     const volumeControlRef = useRef<HTMLDivElement>(null)
-    const y = useMotionValue(percentage)
+    const y = useMotionValue(100 - percentage)
     const dragControls = useDragControls()
 
     useEffect(() => {
-        y.set(percentage, true)
+        y.set(100 - percentage, true)
     }, [y, percentage, volume])
 
     const Icon = percentage === 0 ? IoVolumeMuteOutline :
@@ -35,8 +35,11 @@ const SongAudioControls: React.FC<Props> = ({ volume, setVolume }) => {
     }
 
     function updateVolume() {
-        const yPercent = Math.max(0, Math.min(1, y.get() / 100))
+        console.log("y.get() =", y.get())
+        const yPercent = 1 - Math.max(0, Math.min(1, y.get() / 98))
+        console.log("yPercent =", yPercent)
         const coerced = Math.max(0, Math.min(max, yPercent * max))
+        console.log("coerced =", coerced)
         setVolume(coerced)
     }
 

--- a/src/components/composer/song/SongAudioControls.tsx
+++ b/src/components/composer/song/SongAudioControls.tsx
@@ -13,7 +13,7 @@ const SongAudioControls: React.FC<Props> = ({ volume, setVolume }) => {
     const percentage = (volume / max) * 100
 
     const [expanded, setExpanded] = useState(false)
-    const beforeMute = useRef(volume)
+    const beforeMute = useRef(volume > 0 ? volume : 0.15)
 
     const volumeControlRef = useRef<HTMLDivElement>(null)
     const y = useMotionValue(100 - percentage)
@@ -35,11 +35,8 @@ const SongAudioControls: React.FC<Props> = ({ volume, setVolume }) => {
     }
 
     function updateVolume() {
-        console.log("y.get() =", y.get())
         const yPercent = 1 - Math.max(0, Math.min(1, y.get() / 98))
-        console.log("yPercent =", yPercent)
         const coerced = Math.max(0, Math.min(max, yPercent * max))
-        console.log("coerced =", coerced)
         setVolume(coerced)
     }
 

--- a/src/components/composer/song/SongAudioControls.tsx
+++ b/src/components/composer/song/SongAudioControls.tsx
@@ -4,13 +4,13 @@ import { AnimatePresence, motion, useDragControls, useMotionValue } from "framer
 import { isMobile } from "react-device-detect"
 
 type Props = {
-    targetVolume: number
-    setTargetVolume(value: number): void
+    volume: number
+    setVolume(value: number): void
 }
 
-const SongAudioControls: React.FC<Props> = ({ targetVolume, setTargetVolume }) => {
+const SongAudioControls: React.FC<Props> = ({ volume, setVolume }) => {
     const max = 0.45
-    const percentage = (targetVolume / max) * 100
+    const percentage = (volume / max) * 100
 
     const [expanded, setExpanded] = useState(false)
     const beforeMute = useRef(0.15)
@@ -21,7 +21,7 @@ const SongAudioControls: React.FC<Props> = ({ targetVolume, setTargetVolume }) =
 
     useEffect(() => {
         y.set(percentage, true)
-    }, [y, percentage, targetVolume])
+    }, [y, percentage, volume])
 
     const Icon = percentage === 0 ? IoVolumeMuteOutline :
         percentage > 75 ? IoVolumeHighOutline :
@@ -37,7 +37,7 @@ const SongAudioControls: React.FC<Props> = ({ targetVolume, setTargetVolume }) =
     function updateVolume() {
         const yPercent = Math.max(0, Math.min(1, y.get() / 100))
         const coerced = Math.max(0, Math.min(max, yPercent * max))
-        setTargetVolume(coerced)
+        setVolume(coerced)
     }
 
     const snap: React.MouseEventHandler<HTMLDivElement> = (event) => {
@@ -51,11 +51,11 @@ const SongAudioControls: React.FC<Props> = ({ targetVolume, setTargetVolume }) =
             return
         }
 
-        if (targetVolume === 0) {
-            setTargetVolume(beforeMute.current)
+        if (volume === 0) {
+            setVolume(beforeMute.current)
         } else {
-            beforeMute.current = targetVolume
-            setTargetVolume(0)
+            beforeMute.current = volume
+            setVolume(0)
         }
     }
 

--- a/src/components/composer/song/SongAudioPreview.tsx
+++ b/src/components/composer/song/SongAudioPreview.tsx
@@ -79,7 +79,6 @@ const SongAudioPreview: React.FC<Props> = ({ currentSong, targetVolume }) => {
             audio.volume = coerceVolume(targetVolume)
             fadeInRef.current.to = targetVolume
             fadeOutRef.current.from = targetVolume
-            console.log("changed to targetVolume =", targetVolume)
         }
     }, [targetVolume, currentSong])
 

--- a/src/components/composer/song/SongAudioPreview.tsx
+++ b/src/components/composer/song/SongAudioPreview.tsx
@@ -41,7 +41,7 @@ const SongAudioPreview: React.FC<Props> = ({ currentSong, targetVolume }) => {
         let looping = false
         const listener = async () => {
             setProgress((audio.currentTime / audio.duration) * 100)
-            if (audio.currentTime > audio.duration - 2 && !looping) {
+            if (audio.currentTime > audio.duration - 1.3 && !looping) {
                 looping = true
                 await fadeOutRef.current.start()
                 audio.pause()
@@ -82,7 +82,7 @@ const SongAudioPreview: React.FC<Props> = ({ currentSong, targetVolume }) => {
         }
     }, [targetVolume, currentSong])
 
-    return (
+    return audioRef.current && (
         <>
             <div className="absolute bottom-0 left-0 w-full z-30 h-1.5 bg-emerald-700"/>
             <motion.div

--- a/src/components/composer/song/SongPicker.tsx
+++ b/src/components/composer/song/SongPicker.tsx
@@ -23,7 +23,11 @@ const SongPicker: React.FC<Props> = ({ includedPlaylists, setIncludedSongs }) =>
 
     const x = useMotionValue(0)
 
-    const [targetVolume, setTargetVolume] = useState(.15)
+    const [targetVolume, setTargetVolume] = useState(readFromLocalStorage() ?? 0.15)
+    const setVolume = (value: number) => {
+        writeToLocalStorage(value)
+        setTargetVolume(value)
+    }
 
     useEffect(() => {
         if (state === "done" && index === songs!.length) {
@@ -55,7 +59,7 @@ const SongPicker: React.FC<Props> = ({ includedPlaylists, setIncludedSongs }) =>
     return (
         <div className="w-full flex-grow flex overflow-hidden relative">
             <SongAudioPreview currentSong={currentSong} key={currentSong.track.id} targetVolume={targetVolume}/>
-            <SongAudioControls targetVolume={targetVolume} setTargetVolume={setTargetVolume}/>
+            <SongAudioControls volume={targetVolume} setVolume={setVolume}/>
 
             <SongDragOverlay x={x} onDragEnd={handleDragEnd} />
             <SongDetails x={x} currentSong={currentSong} left={songs.length - index} />
@@ -63,6 +67,18 @@ const SongPicker: React.FC<Props> = ({ includedPlaylists, setIncludedSongs }) =>
             <SongBackground currentSong={currentSong} />
         </div>
     )
+}
+
+function writeToLocalStorage(volume: number) {
+    localStorage.setItem("volume", String(volume))
+}
+
+function readFromLocalStorage(): number | null {
+    const item = localStorage.getItem("volume")
+    if (item) {
+        const number = parseInt(item)
+        return isNaN(number) ? null : number
+    } else return null
 }
 
 export default SongPicker


### PR DESCRIPTION
### New Features
- **Keep volume setting**
The volume is now saved to the local storage in order to keep the setting between multiple page loads.

### Enhancements
- **Flip volume control slider**
The control slider for the volume now increase its value when dragging up, and decrease when dragging down. This is more common than the old approach and thus improves the user experience.
- **Hide progress bar**
The progress bar of the song preview will now only be visible if there actually is a preview available. If not, it will not be displayed to avoid confusion.

### Bug Fixes
- **Unmuting**
By saving the volume in the local storage, an issue has been introduced which would keep the volume at 0% when clicking on the unmute button if that value is saved in the local storage. The bug has been fixed by falling back to the default volume if the previous one represents a muted state.